### PR TITLE
Make compatible with Yap 

### DIFF
--- a/prolog/arbitrary.pl
+++ b/prolog/arbitrary.pl
@@ -1,8 +1,14 @@
 % define arbitrary/2 and friends
 
 :- use_module(library(apply), [maplist/2]).
-:- use_module(library(random), [random_between/3, random_member/2]).
 
+:- if(\+ predicate_property(maplist(_,  _, _),_)).
+
+:- use_module(library(apply_macros), [maplist/3]).
+
+:- endif.
+
+:- use_module(library(random), [random_between/3, random_member/2]).
 :- if(\+predicate_property(random_between(_, _, _), _)).
 
 :- use_module(library(random), [random/3]).

--- a/prolog/arbitrary.pl
+++ b/prolog/arbitrary.pl
@@ -3,6 +3,25 @@
 :- use_module(library(apply), [maplist/2]).
 :- use_module(library(random), [random_between/3, random_member/2]).
 
+:- if(\+predicate_property(random_between(_, _, _), _)).
+
+:- use_module(library(random), [random/3]).
+
+random_between(Lo, Hi, X) :-
+        random(Lo, Hi, X).
+
+:- endif.
+
+:- if(\+predicate_property(random_member(_, _), _)).
+
+random_member(X, Xs) :-
+        length(Xs, N),
+        random_between(1, N, I),
+        nth(I, Xs, X).
+
+:- endif.
+
+
 :- multifile error:has_type/2.
 error:has_type(arbitrary_type, Type) :-
     nonvar(Type),
@@ -53,7 +72,7 @@ arbitrary(float, X) :-
     X is I * random_float.
 
 arbitrary(integer, X) :-
-    random_between(-30_000, 30_000, X).
+    random_between(-30000, 30000, X).
 
 arbitrary(list, X) :-
     arbitrary(list(any), X).
@@ -64,10 +83,10 @@ arbitrary(list(T), X) :-
     maplist(arbitrary(T), X).
 
 arbitrary(negative_integer, X) :-
-    random_between(-30_000, 1, X).
+    random_between(-30000, 1, X).
 
 arbitrary(nonneg, X) :-
-    random_between(0, 30_000, X).
+    random_between(0, 30000, X).
 
 arbitrary(number, X) :-
     random_member(Type, [integer, float]),
@@ -77,7 +96,7 @@ arbitrary(oneof(L), X) :-
     random_member(X, L).
 
 arbitrary(positive_integer, X) :-
-    random_between(1, 30_000, X).
+    random_between(1, 30000, X).
 
 arbitrary(rational, X) :-
     arbitrary(integer, Numerator),

--- a/prolog/shrink.pl
+++ b/prolog/shrink.pl
@@ -1,3 +1,4 @@
+:- use_module(library(lists)).
 
 
 shrink(any, X, X).
@@ -44,7 +45,7 @@ shrink(string, _, X) :-
 shrink_list_bisect(L0, L) :-
     length(L0, Len),
     Len > 0,
-    MaxExponent is ceil(log(Len)),
+    MaxExponent is ceiling(log(Len)),
     between(0,MaxExponent,Exponent),
     N is round(exp(MaxExponent-Exponent)),
     shrink_list_bisect_(L0, Len, N, L).

--- a/t/examples.pl
+++ b/t/examples.pl
@@ -1,4 +1,5 @@
 :- use_module(library(quickcheck)).
+:- use_module(library(lists)).
 
 % reversing a list leaves its length the same
 prop_reverse_length(L:list(integer)) :-


### PR DESCRIPTION
In trying to use this code with Yap prolog, I needed to make some small changes for missing predicates, the digit group syntax extension in SWI, and SWI's autoloaded libraries. 
