### PR TITLE
Fix usage of random predicates in arbitrary.pl

### DIFF
--- a/prolog/arbitrary.pl
+++ b/prolog/arbitrary.pl
@@ -8,7 +8,7 @@
 
 :- endif.
 
-:- use_module(library(random), [random_between/3, random_member/2]).
+:- use_module(library(random), [random_between/3, random_member/2, random/1]).
 :- if(\+predicate_property(random_between(_, _, _), _)).
 
 :- use_module(library(random), [random/3]).
@@ -75,7 +75,8 @@ arbitrary(encoding, X) :-
 
 arbitrary(float, X) :-
     arbitrary(integer, I),
-    X is I * random_float.
+    random(F), 
+    X is I * F.
 
 arbitrary(integer, X) :-
     random_between(-30000, 30000, X).

--- a/prolog/arbitrary.pl
+++ b/prolog/arbitrary.pl
@@ -54,7 +54,11 @@ arbitrary(atomic, X) :-
     arbitrary(Type, X).
 
 arbitrary(between(L,U), X) :-
-    random_between(L,U,X).
+        ((integer(L), integer(U)) ->
+         random_between(L,U,X)
+        ;
+         random(L, U, X)
+        ).
 
 arbitrary(boolean, X) :-
     random_member(X, [true, false]).


### PR DESCRIPTION
Two changes here. 

1) Yap doesn't have random_float/0 as a function, like SWI Prolog, so I just changed it's use in arbitrary.pl to random(X). 

2) `arbitrary(between(L, U))`  was defined in a way that only works with integer L and U, which is not in accordance with the definition of between/2 according to SWI prolog's error.pl. So I changed the definition so that it's meaning is the same as in error.pl. 
